### PR TITLE
Allow password from env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ the `--datadir` option.
 > $ storjshare start --datadir /path/to/custom/datadir
 ```
 
+You can also have the private key's password retrieved from the environment
+variable `STORJSHARE_PASSPHRASE`
+
+```
+> $ STORJSHARE_PASSPHRASE=sup3rS3crEt storjshare start
+```
+
 Running in the Background
 -------------------------
 

--- a/bin/storjshare.js
+++ b/bin/storjshare.js
@@ -112,7 +112,8 @@ var ACTIONS = {
       }
     }
 
-    var password = env.password || process.env.PASSWORD;
+    var password = env.password || process.env.STORJSHARE_PASSPHRASE;
+
     if (password) {
       open(password, privkey);
     } else {

--- a/bin/storjshare.js
+++ b/bin/storjshare.js
@@ -112,8 +112,9 @@ var ACTIONS = {
       }
     }
 
-    if (env.password) {
-      open(env.password, privkey);
+    var password = env.password || process.env.PASSWORD;
+    if (password) {
+      open(password, privkey);
     } else {
       prompt.start();
       prompt.get(UnlockSchema(program), function(err, result) {


### PR DESCRIPTION
Be able to retrieve the password from environment variables

e.x.:
```sh
PASSWORD=itsasecret storjfarm start
# or 
export PASSWORD=itsasecret
storjfarm start
```

If you find the naming of `PASSWORD` too generic, let me know.
Cheers