### PR TITLE
Fixed used space calculation

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -23,12 +23,20 @@ module.exports.getSpeedTestResultPath = function(nodeid) {
 
 module.exports.getDirectorySize = function(dir, callback) {
   fs.stat(dir, function(err, stats) {
-    if (err || !stats.isDirectory()) {
+    if (err) {
+      if (err.code == "ENOENT") {
+        // This file has been removed during size calculation.
+        return callback(null, 0);
+      }
       return callback(err, 0);
     }
 
     var total = stats.size;
 
+    if (!stats.isDirectory()) {
+      return callback(err, total);
+    }
+    
     function done(err) {
       callback(err, total);
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -24,7 +24,7 @@ module.exports.getSpeedTestResultPath = function(nodeid) {
 module.exports.getDirectorySize = function(dir, callback) {
   fs.stat(dir, function(err, stats) {
     if (err) {
-      if (err.code == "ENOENT") {
+      if (err.code === 'ENOENT') {
         // This file has been removed during size calculation.
         return callback(null, 0);
       }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
     {
       "name": "Philip Hutchins",
       "url": "https://phutchins.com"
+    },
+    {
+      "name": "Jeffrey van Binsbergen",
+      "url": "http://jeffreyvanbinsbergen.nl"
     }
   ],
   "license": "AGPL-3.0",


### PR DESCRIPTION
Space was incorrectly calculated by only getting the directory sizes. Now it also looks at the file sizes. Also added a check so deleted files won't cause an error. This should fix #100