### PR TITLE
remove unused dependency

### DIFF
--- a/bin/storjshare.js
+++ b/bin/storjshare.js
@@ -16,7 +16,6 @@ var TelemetryReporter = require('storj-telemetry-reporter');
 var reporter = require('../lib/reporter');
 var utils = require('../lib/utils');
 var log = require('../lib/logger');
-var leveldown = require('leveldown');
 var bitcore = storj.deps.bitcore;
 
 var HOME = platform !== 'win32' ? process.env.HOME : process.env.USERPROFILE;

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "colors": "^1.1.2",
     "commander": "^2.9.0",
     "kad-logger-json": "^0.1.2",
-    "leveldown": "^1.4.6",
     "myspeed": "^1.0.1",
     "prompt": "^1.0.0",
     "storj-lib": "^4.1.0",


### PR DESCRIPTION
LTS nodejs v6.9.1 don't like the unused leveldb and will throw and error.
